### PR TITLE
Rename and harmonise macros

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+# Version <version> (<date>)
+See https://github.com/moewew/biblatex-ext/compare/v0.3...v<version>
+- Renamed `\DeclareOuterCiteDelim` and friends to `\DeclareOuterCiteDelims`,
+  backwards compatibility for most of this change should be available.
+- **Incompatible change** Renamed the cite command `\bbx@cite@inxref` to
+  `\bbx@xrefcite` for consistency with other citation commands.
+  There are is no compatibility code set up for this change.
+- **Incompatible change** The "virtual" citation command `\bbx:introcite`
+  is now called `\bbx@introcite`. ("Virtual" because the appearance of the
+  introcite label can be changed mostly as if it were produced by this citation
+  command, but it isn't really produced by a citation command at all.)
+  This means that the delimiter context, inner citation delimiters and wrapper
+  field format are renamed from `bbx:introcite` to `bbx@introcite`.
+  There is no compatibility code set up for this change, but warnings are
+  issued if some typical uses of the old names are detected. This means that
+  people using older code should be warned, but still need to take action
+  themselves. Fortunately the introcite feature is quite a prominent bit of
+  the bibliography, so people will probably realise wrong output sooner than
+  later.
+- Renamed option `citeinxref` to `citexref`. Please use the new name.
+  Backwards compatibility is in place.
+  
 # Version 0.3 (2018-06-04)
 See https://github.com/moewew/biblatex-ext/compare/v0.2...v0.3
 - Added `titlecase:<titletype>` field formats for finer control over the title

--- a/biblatex-ext.tex
+++ b/biblatex-ext.tex
@@ -116,8 +116,8 @@
     iflistundef,iffieldundef,ifnameundef,
     ExecuteBibliographyOptions,
     DeclareFieldFormat,DeclareDelimFormat,DeclareDelimcontextAlias,
-    DeclareInnerCiteDelim,UndeclareInnerCiteDelim,DeclareInnerCiteDelimAlias,
-    DeclareOuterCiteDelim,UndeclareOuterCiteDelim,DeclareOuterCiteDelimAlias,
+    DeclareInnerCiteDelims,UndeclareInnerCiteDelims,DeclareInnerCiteDelimsAlias,
+    DeclareOuterCiteDelims,UndeclareOuterCiteDelims,DeclareOuterCiteDelimsAlias,
     introcitepunct,volnumdelim,maintitletitledelim,voltitledelim,sernumdelim,
     volnumdatedelim,locdatedelim,locpubdelim,publocdelim,pubdatedelim,
     extradateonlycompcitedelim,introcitesep,introcitewidth,introcitesep},
@@ -391,6 +391,7 @@
 \newrobustcmd*{\bibmacro}[1]{\sty{#1}}
 \renewrobustcmd*{\bibtype}[1]{\sty{@#1}}
 \renewrobustcmd*{\cmd}[1]{\sty{\textbackslash #1}}
+\let\cs\cmd
 \newrobustcmd*{\bibfieldformat}[1]{{\bibfieldformatfont #1}}
 
 \newcommand*{\ctan}{\mkbibacro{CTAN}}
@@ -880,12 +881,12 @@ All other entry types are not affected by this option.
 \makeatother
 \endgroup
 
-\boolitem[false]{citeinxref}
+\boolitem[false]{citexref}
 This option controls if \bibtype{inbook}, \bibtype{incollection} and
 \bibtype{inproceedings} entries that are tied to a parent entry with
 \bibfield{xref} or \bibfield{crossref} should cite their parent in the
 bibliography if the parent is listed in the bibliography as a separate entry.
-With the default setting \kvopt{citeinxref}{false} the parent is not cited, the
+With the default setting \kvopt{citexref}{false} the parent is not cited, the
 entry is shown as in the standard styles. If the option is set to
 \opt{true}, the block following the \enquote{in:} is replaced by a citation
 to the parent entry.
@@ -895,35 +896,35 @@ bibliography, this needs to happen either explicitly by citing the parent
 \opt{mincrossrefs} option.
 
 \nocite{westfahl:frontier}
-\begin{bibexample}[title={\kvopt{citeinxref}{true}}]
+\begin{bibexample}[title={\kvopt{citexref}{true}}]
 \makeatletter
 \renewbibmacro*{crosscite}[1]{%
   \printtext[highlight1]{%
-    \iftoggle{bbx:citeinxref}
+    \iftoggle{bbx:citexref}
       {\iffieldundef{crossref}
          {\iffieldundef{xref}
             {\usebibmacro{#1}}
-            {\printtext{\bbx@cite@inxref{\thefield{xref}}}}}
-         {\printtext{\bbx@cite@inxref{\thefield{crossref}}}}}
+            {\printtext{\bbx@xrefcite{\thefield{xref}}}}}
+         {\printtext{\bbx@xrefcite{\thefield{crossref}}}}}
       {\usebibmacro{#1}}}}
 \makeatother
-\toggletrue{bbx:citeinxref}
+\toggletrue{bbx:citexref}
 \exampleprintbib{westfahl:space}
 \end{bibexample}
 
-\begin{bibexample}[title={\kvopt{citeinxref}{false}}]
+\begin{bibexample}[title={\kvopt{citexref}{false}}]
 \makeatletter
 \renewbibmacro*{crosscite}[1]{%
   \printtext[highlight1]{%
-    \iftoggle{bbx:citeinxref}
+    \iftoggle{bbx:citexref}
       {\iffieldundef{crossref}
          {\iffieldundef{xref}
             {\usebibmacro{#1}}
-            {\printtext{\bbx@cite@inxref{\thefield{xref}}}}}
-         {\printtext{\bbx@cite@inxref{\thefield{crossref}}}}}
+            {\printtext{\bbx@xrefcite{\thefield{xref}}}}}
+         {\printtext{\bbx@xrefcite{\thefield{crossref}}}}}
       {\usebibmacro{#1}}}}
 \makeatother
-\togglefalse{bbx:citeinxref}
+\togglefalse{bbx:citexref}
 \exampleprintbib{westfahl:space}
 \end{bibexample}
 
@@ -1195,7 +1196,7 @@ labels in a \sty{numeric} bibliography.
 \begingroup
 \togglefalse{bbx:doi}
 \setlength{\introcitewidth}{5.5\biblabelsep}
-\DeclareFieldFormat{bbx:introcite}{\highlight{#1}}
+\DeclareFieldFormat{bbx@introcite}{\highlight{#1}}
 \renewcommand*{\introcitepunct}{\highlight{\addcolon}\space}
 \makeatletter
 \begin{bibexample}[title={\kvopt{introcite}{false}}]
@@ -1247,7 +1248,7 @@ The label produced by the \opt{plain} option can be customised as follows.
 \renewbibmacro*{related:init}{%
   \csundef{bbx:relatedloop}%
   \iftoggle{bbx:introcite:plain:keeprelated}{%
-    \DeclareFieldFormat{bbx:introcite}{\highlight{##1}}%
+    \DeclareFieldFormat{bbx@introcite}{\highlight{##1}}%
     \renewcommand*{\introcitepunct}{\highlight{\addcolon}\space}%
   }{\renewbibmacro{introcite:plain}{}}}
 \csuse{extblx@opt@dashed@false}
@@ -1321,25 +1322,26 @@ overlay={%
 \makeatother
 
 The appearance of the citation label can be customised mostly as if it were
-produced by a true citation command called \cmd{bbx:introcite}.
-The delimiter context is \sty{bbx:introcite}, the inner citation delimiters
-can be accessed as \sty{bbx:introcite} as well.
+produced by a true citation command called \cmd{bbx@introcite}.
+The delimiter context is \sty{bbx@introcite}, the inner citation delimiters
+can be accessed as \sty{bbx@introcite} as well.
 The label does not have outer citation delimiters, you can use the wrapper
-field format \sty{bbx:introcite} instead. In fact this approach is more
+field format \sty{bbx@introcite} instead. In fact this approach is more
 versatile than the outer citation delimiter feature (see the discussion in
 \cref{sec:opt:citedelims}).
+The default settings for \cmd{bbx@introcite} emulate the output of \cmd{cite}.
 
 \begin{bibexample}[title={Example customisations for \kvopt{introcite}{plain}}]
 \begin{lstlisting}[style=extblxstylelatex]
-\DeclareFieldFormat{bbx:introcite}{\mkbibbrackets{#1}}
-\DeclareDelimFormat[bbx:introcite]{nameyeardelim}{\addcomma\space}
-\UndeclareInnerCiteDelim{bbx:introcite}
+\DeclareFieldFormat{bbx@introcite}{\mkbibbrackets{#1}}
+\DeclareDelimFormat[bbx@introcite]{nameyeardelim}{\addcomma\space}
+\UndeclareInnerCiteDelims{bbx@introcite}
 \renewcommand*{\introcitepunct}{\quad}
 \end{lstlisting}
 \tcblower
-\DeclareFieldFormat{bbx:introcite}{\mkbibbrackets{#1}}
-\DeclareDelimFormat[bbx:introcite]{nameyeardelim}{\addcomma\space}
-\UndeclareInnerCiteDelim{bbx:introcite}
+\DeclareFieldFormat{bbx@introcite}{\mkbibbrackets{#1}}
+\DeclareDelimFormat[bbx@introcite]{nameyeardelim}{\addcomma\space}
+\UndeclareInnerCiteDelims{bbx@introcite}
 \renewcommand*{\introcitepunct}{\quad}
 \csuse{extblx@opt@dashed@false}
 \csletcs{extblx@introcite}{extblx@opt@introcite@plain}
@@ -1348,23 +1350,23 @@ versatile than the outer citation delimiter feature (see the discussion in
 
 \begin{bibexample}[title={Example customisations for \kvopt{introcite}{label}}]
 \begin{lstlisting}[style=extblxstylelatex]
-\DeclareFieldFormat{bbx:introcite}{\mkbibbold{#1}}
-\DeclareDelimcontextAlias{bbx:introcite}{textcite}
-\DeclareInnerCiteDelim{bbx:introcite}{\bibopenparen}{\bibcloseparen}
+\DeclareFieldFormat{bbx@introcite}{\mkbibbold{#1}}
+\DeclareDelimcontextAlias{bbx@introcite}{textcite}
+\DeclareInnerCiteDelims{bbx@introcite}{\bibopenparen}{\bibcloseparen}
 \setlength{\introcitewidth}{0pt}
 \setlength{\introcitesep}{\bibhang}
 \end{lstlisting}
 \tcblower
-\DeclareFieldFormat{bbx:introcite}{\mkbibbold{#1}}
-\DeclareDelimcontextAlias{bbx:introcite}{textcite}
-\DeclareInnerCiteDelim{bbx:introcite}{\bibopenparen}{\bibcloseparen}
+\DeclareFieldFormat{bbx@introcite}{\mkbibbold{#1}}
+\DeclareDelimcontextAlias{bbx@introcite}{textcite}
+\DeclareInnerCiteDelims{bbx@introcite}{\bibopenparen}{\bibcloseparen}
 \setlength{\introcitewidth}{0pt}
 \setlength{\introcitesep}{\bibhang}
 \csuse{extblx@opt@dashed@false}
 \csletcs{extblx@introcite}{extblx@opt@introcite@label}
 \exampleprintbib{coleridge,geer}
 \end{bibexample}
-\csgundef{blx@delimcontextalias@bbx:introcite}
+\csgundef{blx@delimcontextalias@bbx@introcite}
 % because \DeclareDelimcontextAlias is global ... at the moment, this can go
 % with biblatex >= 3.12
 
@@ -1793,7 +1795,7 @@ Style family & \cmd{cite} & \cmd{parencite} & \cmd{textcite}\\
         {closing delimiter}
 
 Sets up the outer delimiters for the citation command
-\cmd{$\langle$\emph{cite command}$\rangle$}. The name of the \prm{cite command}
+\cmd{\prm{cite command}}. The name of the \prm{cite command}
 is given without leading backslash in the argument, it normally corresponds to
 the delimiter context.
 
@@ -1826,24 +1828,24 @@ commands respond to nesting and check if opening brackets are always closed.
 \cmditem{DeclareOuterCiteDelimAlias}{cite alias}{cite command}
 \cmditem*{DeclareOuterCiteDelimAlias*}{cite alias}{cite command}
 
-Use the outer delimiters of \cmd{$\langle$\emph{cite command}$\rangle$} for
-\cmd{$\langle$\emph{cite alias}$\rangle$} as well.
+Use the outer delimiters of \cmd{\prm{cite command}} for
+\cmd{\prm{cite alias}} as well.
 The unstarred version uses \cmd{def} assignment while the starred version uses
 \cmd{let}. This means that the starred version copies the values of the
 definitions at the time of executing the aliasing command,
 whereas the alias created by the unstarred version will only evaluate the
 delimiters whenever the citation command is called.
 
-\cmditem{UndeclareOuterCiteDelim}{cite command}
+\cmditem{UndeclareOuterCiteDelims}{cite command}
 
 Completely remove the definitions of the outer delimiters for
-\cmd{$\langle$\emph{cite command}$\rangle$}.
+\cmd{\prm{cite command}}.
 
 \cmditem{DeclareInnerCiteDelim}{cite command}{opening delimiter}
         {closing delimiter}
 
 Sets up the inner delimiters for the citation command
-\cmd{$\langle$\emph{cite command}$\rangle$}.
+\cmd{\prm{cite command}}.
 
 This command is similar to \cmd{DeclareOuterCiteDelim} and the same
 restrictions for the arguments apply.
@@ -1856,41 +1858,85 @@ This may lead to initially surprising results if aliases are used.
 \cmditem{DeclareInnerCiteDelimAlias}{cite alias}{cite command}
 \cmditem*{DeclareInnerCiteDelimAlias*}{cite alias}{cite command}
 
-Use the inner delimiters of \cmd{$\langle$\emph{cite command}$\rangle$} for
-\cmd{$\langle$\emph{cite alias}$\rangle$} as well.
+Use the inner delimiters of \cmd{\prm{cite command}} for
+\cmd{\prm{cite alias}} as well.
 The unstarred version uses \cmd{def} assignment while the starred version uses
 \cmd{let}. This means that the starred version copies the values of the
 definitions at the time of executing the aliasing command,
 whereas the alias created by the unstarred version will only evaluate the
 delimiters whenever the citation command is called.
 
-\cmditem{UndeclareInnerCiteDelim}{cite command}
+\cmditem{UndeclareInnerCiteDelims}{cite command}
 
 Completely remove the definitions of the inner delimiters for
-\cmd{$\langle$\emph{cite command}$\rangle$}.
+\cmd{\prm{cite command}}.
+
+\cmditem{RegisterCiteDelims}{modifier}{cite command}
+
+Register a pair of \prm{modifier} citation delimiters for
+\cmd{\prm{cite command}}.
+This command will define a delimiter wrapper command
+\cmd{mk\prm{modifier}\prm{cite command}s} that places its argument between
+the opening delimiter
+\cs{ext\allowbreak blx@\allowbreak cite\allowbreak delim@\allowbreak
+  \prm{cite command}@\allowbreak\prm{modifier}@\allowbreak open} and
+the closing delimiter
+\cs{ext\allowbreak blx@\allowbreak cite\allowbreak delim@\allowbreak
+  \prm{cite command}@\allowbreak\prm{modifier}@\allowbreak close}.
+No error will be raised if the opening or closing delimiters are not defined,
+but an error will be raised if \cmd{mk\prm{modifier}\prm{cite command}s} is
+already defined.
+
+The styles of this bundle only use the values \opt{outer} and \opt{inner} for
+\prm{modifier}, but other values are possible. With \opt{outer} and \opt{inner}
+you can use \cmd{DeclareOuterCiteDelim} or \cmd{DeclareInnerCiteDelim} and
+friends to define the opening and closing delimiters, otherwise you need to
+define them manually.
+
+All styles of \sty{biblatex-ext} define the following wrapper commands
+\begin{table}[btph]
+\centering
+\caption{Delimiter wrappers defined by \sty{biblatex-ext}}
+\label{tab:delimwrappers}
+\begin{tabular}{@{}lll@{}}
+\toprule
+                 & \multicolumn{2}{c}{Modifier} \\
+                 \cmidrule(lr){2-3}
+Citation command & Outer & Inner\\
+\midrule
+\cmd{cite} & \cmd{mkoutercitedelims} & \cmd{mkinnercitedelims}\\
+\cmd{parencite} & \cmd{mkouterparencitedelims} & \cmd{mkinnerparencitedelims}\\
+\cmd{textcite} & \cmd{mkoutertextcitedelims} & \cmd{mkinnertextcitedelims}\\
+\cmd{footcite} &  & \cmd{mkinnerfootcitedelims}\\
+\cmd{bbx@xrefcite} & \cmd{mkouterbbx@xrefcitedelims} & \cmd{mkinnerbbx@xrefcitedelims}\\
+\enquote{\cmd{bbx@introcite}} &  & \cmd{mkinnerbbx@introcitedelims}\\
+\bottomrule
+\end{tabular}
+\end{table}
+
 
 The \sty{authoryear} and \sty{authortitle} styles have \cmd{parencite},
 e.g.\ \parencite{knuth:ct:a}, \parencite{sigfridsson}, set up with
 \begin{biblatexcode}
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
-\DeclareInnerCiteDelim{parencite}{}{}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{parencite}{}{}
 \end{biblatexcode}
 and \cmd{textcite}, e.g.\ \textcite{knuth:ct:a}, \textcite{sigfridsson}, with
 \begin{biblatexcode}
-\DeclareOuterCiteDelim{textcite}{}{}
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{textcite}{}{}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 \end{biblatexcode}
 If you wanted \cmd{parencite} of \sty{authoryear} to look like
 \enquote{[Sigfridsson and Worman (1998)]} you would use
 \begin{biblatexcode}
-\DeclareOuterCiteDelim{parencite}{|1\bibopenbracket1|}{|1\bibclosebracket1|}
-\DeclareInnerCiteDelim{parencite}{|2\bibopenparen2|}{|2\bibcloseparen2|}
+\DeclareOuterCiteDelims{parencite}{|1\bibopenbracket1|}{|1\bibclosebracket1|}
+\DeclareInnerCiteDelims{parencite}{|2\bibopenparen2|}{|2\bibcloseparen2|}
 \end{biblatexcode}
 \citereset
 \begin{bibexample}
-\DeclareOuterCiteDelim{parencite}{\highlightbf[1]{\bibopenbracket}}{%
+\DeclareOuterCiteDelims{parencite}{\highlightbf[1]{\bibopenbracket}}{%
   \highlightbf[1]{\bibclosebracket}}
-\DeclareInnerCiteDelim{parencite}{\highlightbf[2]{\bibopenparen}}{%
+\DeclareInnerCiteDelims{parencite}{\highlightbf[2]{\bibopenparen}}{%
   \highlightbf[2]{\bibcloseparen}}
 \parencite{sigfridsson}\quad\parencite{worman,geer}\quad
 \parencite{knuth:ct:a,knuth:ct:b,knuth:ct:c}
@@ -1981,6 +2027,16 @@ The GitHub repository of this project uses release tags, so you can compare
 the changes in source code there.\footnote{\url{\gitbaseurl/compare/}}
 See also \sty{CHANGES.md}.
 \begin{changelog}
+\begin{release}{<version>}{<date>}
+\item Renamed \cmd{DeclareOuterCiteDelim} and friends to
+  \cmd{DeclareOuterCiteDelims}
+  \see{sec:opt:citedelims}
+\item Added \cmd{RegisterCiteDelims}
+  \see{sec:opt:citedelims}
+\item Renamed \enquote{virtual} cite command \cmd{bbx:introcite} to
+  \cmd{bbx@introcite}
+  \see{sec:opt:style}
+\end{release}
 \begin{release}{0.3}{2018-06-04}
 \item Added \bibfieldformat{titlecase:\dots title} field formats%
   \see{sec:opt:field}

--- a/biblatex-ext.tex
+++ b/biblatex-ext.tex
@@ -1351,14 +1351,14 @@ The default settings for \cmd{bbx@introcite} emulate the output of \cmd{cite}.
 \begin{bibexample}[title={Example customisations for \kvopt{introcite}{label}}]
 \begin{lstlisting}[style=extblxstylelatex]
 \DeclareFieldFormat{bbx@introcite}{\mkbibbold{#1}}
-\DeclareDelimcontextAlias{bbx@introcite}{textcite}
+\DeclareDelimFormat[bbx@introcite]{nameyeardelim}{\addspace}
 \DeclareInnerCiteDelims{bbx@introcite}{\bibopenparen}{\bibcloseparen}
 \setlength{\introcitewidth}{0pt}
 \setlength{\introcitesep}{\bibhang}
 \end{lstlisting}
 \tcblower
 \DeclareFieldFormat{bbx@introcite}{\mkbibbold{#1}}
-\DeclareDelimcontextAlias{bbx@introcite}{textcite}
+\DeclareDelimFormat[bbx@introcite]{nameyeardelim}{\addspace}
 \DeclareInnerCiteDelims{bbx@introcite}{\bibopenparen}{\bibcloseparen}
 \setlength{\introcitewidth}{0pt}
 \setlength{\introcitesep}{\bibhang}

--- a/ext-alphabetic-verb.cbx
+++ b/ext-alphabetic-verb.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{alphabetic-verb}
 
-\DeclareOuterCiteDelim{cite}{\bibopenbracket}{\bibclosebracket}
-\DeclareOuterCiteDelimAlias{parencite}{cite}
-\DeclareOuterCiteDelim{textcite}{}{}
+\DeclareOuterCiteDelims{cite}{\bibopenbracket}{\bibclosebracket}
+\DeclareOuterCiteDelimsAlias{parencite}{cite}
+\DeclareOuterCiteDelims{textcite}{}{}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenbracket}{\bibclosebracket}
+\DeclareInnerCiteDelims{textcite}{\bibopenbracket}{\bibclosebracket}
 
 \renewbibmacro*{textcite}{%
   \ifnameundef{labelname}
@@ -35,7 +35,7 @@
   {\usebibmacro{postnote}%
    \csuse{extblx@citedelim@cite@outer@close}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -51,7 +51,7 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\textcite}[\mkoutertextcitedelims]
   {}
   {\usebibmacro{citeindex}%
    \iffirstcitekey
@@ -63,11 +63,11 @@
   {\usebibmacro{postnote}%
    \csuse{extblx@citedelim@\blx@delimcontext @inner@close}}
 
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
-\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelim]{\textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelims]{\textcite}{}
 
 \endinput
 %

--- a/ext-alphabetic.cbx
+++ b/ext-alphabetic.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{alphabetic}
 
-\DeclareOuterCiteDelim{cite}{\bibopenbracket}{\bibclosebracket}
-\DeclareOuterCiteDelimAlias{parencite}{cite}
-\DeclareOuterCiteDelim{textcite}{}{}
+\DeclareOuterCiteDelims{cite}{\bibopenbracket}{\bibclosebracket}
+\DeclareOuterCiteDelimsAlias{parencite}{cite}
+\DeclareOuterCiteDelims{textcite}{}{}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenbracket}{\bibclosebracket}
+\DeclareInnerCiteDelims{textcite}{\bibopenbracket}{\bibclosebracket}
 
 \renewbibmacro*{textcite}{%
   \iffieldequals{namehash}{\cbx@lasthash}
@@ -50,14 +50,14 @@
          {}%
        \textcitedelim}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -73,19 +73,19 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
   {}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-authortitle-comp.cbx
+++ b/ext-authortitle-comp.cbx
@@ -6,12 +6,12 @@
 
 \RequireCitationStyle{authortitle-comp}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{cite}{}{}
-\DeclareInnerCiteDelim{parencite}{}{}
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
-\DeclareInnerCiteDelim{footcite}{}{}
+\DeclareInnerCiteDelims{cite}{}{}
+\DeclareInnerCiteDelims{parencite}{}{}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{footcite}{}{}
 
 \renewbibmacro*{cite}{%
   \iffieldundef{shorthand}
@@ -87,7 +87,7 @@
          {}%
        \textcitedelim}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -95,7 +95,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -103,7 +103,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -111,7 +111,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -129,29 +129,29 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{cite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
   {}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\setunit{\multicitedelim}}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\setunit{\multicitedelim}}
 
-\DeclareCiteCommand{\bbx@cite@inxref}[\mkouterbibinxrefcitedelim]
+\DeclareCiteCommand{\bbx@xrefcite}[\mkouterbbx@xrefcitedelims]
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \boolfalse{backtracker}%
    \usebibmacro{cite:init}}
-  {\usebibmacro{bbx:cite:inxref}}
+  {\usebibmacro{bbx:inxrefcite}}
   {}
   {\usebibmacro{cite:postnote}}
 

--- a/ext-authortitle-ibid.cbx
+++ b/ext-authortitle-ibid.cbx
@@ -6,20 +6,20 @@
 
 \RequireCitationStyle{authortitle-ibid}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{cite}{}{}
-\DeclareInnerCiteDelim{parencite}{}{}
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
-\DeclareInnerCiteDelim{footcite}{}{}
+\DeclareInnerCiteDelims{cite}{}{}
+\DeclareInnerCiteDelims{parencite}{}{}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{footcite}{}{}
 
-\DeclareFieldFormat{extblx@innercitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innerparencitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innertextcitedelim}{#1}
-\DeclareFieldFormat{extblx@innerfootcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{extblx@innercitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innerparencitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innertextcitedelims}{#1}
+\DeclareFieldFormat{extblx@innerfootcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \newbibmacro*{textcite}{%
   \global\boolfalse{cbx:loccit}%
@@ -38,7 +38,7 @@
     {\usebibmacro{cite:shorthand}}}
 
 \renewbibmacro*{cite:title}{%
-  \printtext[extblx@inner\blx@delimcontext delim]{%
+  \printtext[extblx@inner\blx@delimcontext delims]{%
     \printtext[bibhyperref]{%
       \printfield[citetitle]{labeltitle}}}}
 
@@ -54,28 +54,28 @@
      \printfield{postnote}%
      \csuse{extblx@citedelim@\blx@delimcontext @inner@close}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citetitle}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citetitle}}
@@ -91,7 +91,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\textcite}[\mkoutertextcitedelims]
   {\boolfalse{cbx:parens}}
   {\usebibmacro{citeindex}%
    \iffirstcitekey
@@ -105,16 +105,16 @@
      {}}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
-\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelim]{\textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelims]{\textcite}{}
 
-\DeclareFieldFormat{extblx@innerbbx:introcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{extblx@innerbbx@introcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \endinput
 %

--- a/ext-authortitle-icomp.cbx
+++ b/ext-authortitle-icomp.cbx
@@ -6,12 +6,12 @@
 
 \RequireCitationStyle{authortitle-icomp}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{cite}{}{}
-\DeclareInnerCiteDelim{parencite}{}{}
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
-\DeclareInnerCiteDelim{footcite}{}{}
+\DeclareInnerCiteDelims{cite}{}{}
+\DeclareInnerCiteDelims{parencite}{}{}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{footcite}{}{}
 
 \renewbibmacro*{cite}{%
   \iffieldundef{shorthand}
@@ -95,7 +95,7 @@
          {}%
        \textcitedelim}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -103,7 +103,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -111,7 +111,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -119,7 +119,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -137,29 +137,29 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{cite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
   {}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\setunit{\multicitedelim}}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\setunit{\multicitedelim}}
 
-\DeclareCiteCommand{\bbx@cite@inxref}[\mkouterbibinxrefcitedelim]
+\DeclareCiteCommand{\bbx@xrefcite}[\mkouterbbx@xrefcitedelims]
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \boolfalse{backtracker}%
    \usebibmacro{cite:init}}
-  {\usebibmacro{bbx:cite:inxref}}
+  {\usebibmacro{bbx:inxrefcite}}
   {}
   {\usebibmacro{cite:postnote}}
 

--- a/ext-authortitle.cbx
+++ b/ext-authortitle.cbx
@@ -5,20 +5,20 @@
 
 \RequireCitationStyle{authortitle}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{cite}{}{}
-\DeclareInnerCiteDelim{parencite}{}{}
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
-\DeclareInnerCiteDelim{footcite}{}{}
+\DeclareInnerCiteDelims{cite}{}{}
+\DeclareInnerCiteDelims{parencite}{}{}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{footcite}{}{}
 
-\DeclareFieldFormat{extblx@innercitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innerparencitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innertextcitedelim}{#1}
-\DeclareFieldFormat{extblx@innerfootcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{extblx@innercitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innerparencitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innertextcitedelims}{#1}
+\DeclareFieldFormat{extblx@innerfootcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \renewbibmacro*{textcite}{%
   \printnames{labelname}%
@@ -34,7 +34,7 @@
     {\usebibmacro{cite:shorthand}}}
 
 \renewbibmacro*{cite:title}{%
-  \printtext[extblx@inner\blx@delimcontext delim]{%
+  \printtext[extblx@inner\blx@delimcontext delims]{%
     \printtext[bibhyperref]{%
       \printfield[citetitle]{labeltitle}}}}
 
@@ -50,28 +50,28 @@
      \printfield{postnote}%
      \csuse{extblx@citedelim@\blx@delimcontext @inner@close}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citetitle}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citetitle}}
@@ -87,7 +87,7 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\textcite}[\mkoutertextcitedelims]
   {\boolfalse{cbx:parens}}
   {\usebibmacro{citeindex}%
    \iffirstcitekey
@@ -101,16 +101,16 @@
      {}}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
-\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelim]{\textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelims]{\textcite}{}
 
-\DeclareFieldFormat{extblx@innerbbx:introcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{extblx@innerbbx@introcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \endinput
 %

--- a/ext-authoryear-comp.cbx
+++ b/ext-authoryear-comp.cbx
@@ -6,9 +6,9 @@
 
 \RequireCitationStyle{authoryear-comp}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
 \DeclareFieldFormat{citelabeldate}{#1}
 \DeclareFieldFormat{parencitelabeldate}{#1}
@@ -143,7 +143,7 @@
          {}%
        \textcitedelim}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -151,7 +151,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -159,7 +159,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -167,7 +167,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -201,29 +201,29 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{cite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
   {}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\setunit{\multicitedelim}}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\setunit{\multicitedelim}}
 
-\DeclareCiteCommand{\bbx@cite@inxref}[\mkouterbibinxrefcitedelim]
+\DeclareCiteCommand{\bbx@xrefcite}[\mkouterbbx@xrefcitedelims]
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \boolfalse{backtracker}%
    \usebibmacro{cite:init}}
-  {\usebibmacro{bbx:cite:inxref}}
+  {\usebibmacro{bbx:inxrefcite}}
   {}
   {\usebibmacro{cite:postnote}}
 

--- a/ext-authoryear-ibid.cbx
+++ b/ext-authoryear-ibid.cbx
@@ -6,17 +6,17 @@
 
 \RequireCitationStyle{authoryear-ibid}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareFieldFormat{extblx@innercitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innerparencitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innertextcitedelim}{#1}
-\DeclareFieldFormat{extblx@innerfootcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{extblx@innercitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innerparencitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innertextcitedelims}{#1}
+\DeclareFieldFormat{extblx@innerfootcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \DeclareFieldFormat{citelabeldate}{#1}
 \DeclareFieldFormat{parencitelabeldate}{#1}
@@ -26,7 +26,7 @@
 \renewbibmacro*{cite:labeldate+extradate}{%
   \iffieldundef{labelyear}
     {}
-    {\printtext[extblx@inner\blx@delimcontext delim]{%
+    {\printtext[extblx@inner\blx@delimcontext delims]{%
        \printtext[bibhyperref]{%
          \printtext[\blx@delimcontext labeldate]{%
            \printlabeldateextra}}}}}
@@ -73,28 +73,28 @@
      \printfield{postnote}%
      \csuse{extblx@citedelim@\blx@delimcontext @inner@close}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
@@ -110,7 +110,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\textcite}[\mkoutertextcitedelims]
   {\boolfalse{cbx:parens}}
   {\usebibmacro{citeindex}%
    \iffirstcitekey
@@ -124,17 +124,17 @@
      {}}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
-\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelim]{\textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelims]{\textcite}{}
 
-\DeclareFieldFormat{bbx:introcitelabeldate}{#1}
-\DeclareFieldFormat{extblx@innerbbx:introcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{bbx@introcitelabeldate}{#1}
+\DeclareFieldFormat{extblx@innerbbx@introcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \endinput
 %

--- a/ext-authoryear-icomp.cbx
+++ b/ext-authoryear-icomp.cbx
@@ -6,9 +6,9 @@
 
 \RequireCitationStyle{authoryear-icomp}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
 \DeclareFieldFormat{citelabeldate}{#1}
 \DeclareFieldFormat{parencitelabeldate}{#1}
@@ -153,7 +153,7 @@
          {}%
        \textcitedelim}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -161,7 +161,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -169,7 +169,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -177,7 +177,7 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -195,29 +195,29 @@
   {}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{cite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
   {}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\setunit{\multicitedelim}}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\setunit{\multicitedelim}}
 
-\DeclareCiteCommand{\bbx@cite@inxref}[\mkouterbibinxrefcitedelim]
+\DeclareCiteCommand{\bbx@xrefcite}[\mkouterbbx@xrefcitedelims]
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \boolfalse{backtracker}%
    \usebibmacro{cite:init}}
-  {\usebibmacro{bbx:cite:inxref}}
+  {\usebibmacro{bbx:inxrefcite}}
   {}
   {\usebibmacro{cite:postnote}}
 

--- a/ext-authoryear.cbx
+++ b/ext-authoryear.cbx
@@ -5,17 +5,17 @@
 
 \RequireCitationStyle{authoryear}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareFieldFormat{extblx@innercitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innerparencitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
-\DeclareFieldFormat{extblx@innertextcitedelim}{#1}
-\DeclareFieldFormat{extblx@innerfootcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{extblx@innercitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innerparencitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
+\DeclareFieldFormat{extblx@innertextcitedelims}{#1}
+\DeclareFieldFormat{extblx@innerfootcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \DeclareFieldFormat{citelabeldate}{#1}
 \DeclareFieldFormat{parencitelabeldate}{#1}
@@ -25,7 +25,7 @@
 \renewbibmacro*{cite:labeldate+extradate}{%
   \iffieldundef{labelyear}
     {}
-    {\printtext[extblx@inner\blx@delimcontext delim]{%
+    {\printtext[extblx@inner\blx@delimcontext delims]{%
        \printtext[bibhyperref]{%
          \printtext[\blx@delimcontext labeldate]{%
            \printlabeldateextra}}}}}
@@ -65,28 +65,28 @@
      \printfield{postnote}%
      \csuse{extblx@citedelim@\blx@delimcontext @inner@close}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand*{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand*{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand*{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand*{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{citeyear}}
@@ -102,7 +102,7 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\textcite}[\mkoutertextcitedelims]
   {\boolfalse{cbx:parens}}
   {\usebibmacro{citeindex}%
    \iffirstcitekey
@@ -116,17 +116,17 @@
      {}}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
-\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelim]{\textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelims]{\textcite}{}
 
-\DeclareFieldFormat{bbx:introcitelabeldate}{#1}
-\DeclareFieldFormat{extblx@innerbbx:introcitedelim}{%
-  \csuse{mkinner\blx@delimcontext delim}{#1}}
+\DeclareFieldFormat{bbx@introcitelabeldate}{#1}
+\DeclareFieldFormat{extblx@innerbbx@introcitedelims}{%
+  \csuse{mkinner\blx@delimcontext delims}{#1}}
 
 \endinput
 %

--- a/ext-biblatex-aux.def
+++ b/ext-biblatex-aux.def
@@ -4,57 +4,76 @@
 \def\extblx@requiredbiblatexversion{3.11}
 \def\extblx@requiredbiblatexdate{2018/02/20}
 
+\newrobustcmd*{\extblx@warning}[1]{\PackageWarning{biblatex-ext}{#1}}
+\newrobustcmd*{\extblx@warning@noline}[1]{\PackageWarningNoLine{biblatex-ext}{#1}}
+
+\newrobustcmd*{\extblx@error}[2]{\PackageError{biblatex-ext}{#1}{#2.}}
+
 \@ifpackagelater{biblatex}{\extblx@requiredbiblatexdate}
   {}
-  {\PackageWarningNoLine{extbiblatex}
-     {Outdated version of biblatex detected.\MessageBreak
+  {\extblx@warning@noline{%
+      Outdated version of biblatex detected.\MessageBreak
       Upgrade to biblatex \extblx@requiredbiblatexversion\space
       (\extblx@requiredbiblatexdate) or later.\MessageBreak
       I found '\csuse{abx@version} (\csuse{abx@date})'}}
 
 %{<context>}{<opening delim>}{<closing delim>}
-\newcommand*{\DeclareOuterCiteDelim}{%
-  \extblx@declareciteddelim{outer}}
-\newrobustcmd*{\DeclareInnerCiteDelim}{%
-  \extblx@declareciteddelim{inner}}
+\newrobustcmd*{\DeclareOuterCiteDelims}{%
+  \extblx@declareciteddelims{outer}}
+\newrobustcmd*{\DeclareInnerCiteDelims}{%
+  \extblx@declareciteddelims{inner}}
 
 %{<inner/outer>}{<cite context>}{<opening delim>}{<closing delim>}
-\def\extblx@declareciteddelim#1#2#3#4{%
+\def\extblx@declareciteddelims#1#2#3#4{%
   \csdef{extblx@citedelim@#2@#1@open}{#3}%
   \csdef{extblx@citedelim@#2@#1@close}{#4}}
 
 %{<context>}
-\newcommand*{\UndeclareOuterCiteDelim}{%
-  \extblx@undeclareciteddelim{outer}}
-\newrobustcmd*{\UndeclareInnerCiteDelim}{%
-  \extblx@undeclareciteddelim{inner}}
+\newrobustcmd*{\UndeclareOuterCiteDelims}{%
+  \extblx@undeclareciteddelims{outer}}
+\newrobustcmd*{\UndeclareInnerCiteDelims}{%
+  \extblx@undeclareciteddelims{inner}}
 
 %{<inner/outer>}{<cite context>}
-\def\extblx@undeclareciteddelim#1#2{%
+\def\extblx@undeclareciteddelims#1#2{%
   \csundef{extblx@citedelim@#2@#1@open}%
   \csundef{extblx@citedelim@#2@#1@close}}
 
 %{<alias>}{<cite context>}
-\newcommand*{\DeclareOuterCiteDelimAlias}{%
+\newrobustcmd*{\DeclareOuterCiteDelimsAlias}{%
   \@ifstar
-    {\extblx@declareciteddelim@alias@i{outer}}
-    {\extblx@declareciteddelim@alias{outer}}}
-\newcommand*{\DeclareInnerCiteDelimAlias}{%
+    {\extblx@declareciteddelims@alias@i{outer}}
+    {\extblx@declareciteddelims@alias{outer}}}
+\newrobustcmd*{\DeclareInnerCiteDelimsAlias}{%
   \@ifstar
-    {\extblx@declareciteddelim@alias@i{inner}}
-    {\extblx@declareciteddelim@alias{inner}}}
+    {\extblx@declareciteddelims@alias@i{inner}}
+    {\extblx@declareciteddelims@alias{inner}}}
 
 %{<inner/outer>}{<alias>}{<cite context>}
-\def\extblx@declareciteddelim@alias#1#2#3{%
+\def\extblx@declareciteddelims@alias#1#2#3{%
   \csdef{extblx@citedelim@#2@#1@open}{\csuse{extblx@citedelim@#3@#1@open}}%
   \csdef{extblx@citedelim@#2@#1@close}{\csuse{extblx@citedelim@#3@#1@close}}}
-\def\extblx@declareciteddelim@alias@i#1#2#3{%
+\def\extblx@declareciteddelims@alias@i#1#2#3{%
   \csletcs{extblx@citedelim@#2@#1@open}{extblx@citedelim@#3@#1@open}%
   \csletcs{extblx@citedelim@#2@#1@close}{extblx@citedelim@#3@#1@close}}
 
 % declare \mk...delim commands
-\newrobustcmd*{\extblx@create@mkcitedelim}[2]{%
-  \protected\csdef{mk#1#2delim}##1{%
+\newrobustcmd*{\RegisterCiteDelims}[2]{%
+  \ifcsundef{mk#1#2delims}
+    {}
+    {\extblx@error
+       {Command \expandafter\string\csname mk#1#2delims\endcsname\space
+        already defined}
+       {biblatex-ext needs to define this command for the citation delimiter
+        feature,\MessageBreak
+        but \expandafter\string\csname mk#1#2delims\endcsname\space
+        is already defined.\MessageBreak
+        I don't want to overwrite the existing definition to avoid breaking
+        your document.\MessageBreak
+        If you force compilation despite the error, the command will be
+        overwritten\MessageBreak
+        with potentially catastrophic consequences}}%
+  \protected\csdef{mk#1#2delims}##1{%
     \begingroup
       \blx@blxinit
       \blx@setsfcodes
@@ -63,15 +82,15 @@
       \csuse{extblx@citedelim@#2@#1@close}%
     \endgroup}}
 
-\extblx@create@mkcitedelim{outer}{cite}
-\extblx@create@mkcitedelim{outer}{parencite}
-\extblx@create@mkcitedelim{outer}{textcite}
-\extblx@create@mkcitedelim{outer}{bibinxrefcite}
+\RegisterCiteDelims{outer}{cite}
+\RegisterCiteDelims{outer}{parencite}
+\RegisterCiteDelims{outer}{textcite}
 
-\extblx@create@mkcitedelim{inner}{cite}
-\extblx@create@mkcitedelim{inner}{parencite}
-\extblx@create@mkcitedelim{inner}{textcite}
-\extblx@create@mkcitedelim{inner}{footcite}
+\RegisterCiteDelims{inner}{cite}
+\RegisterCiteDelims{inner}{parencite}
+\RegisterCiteDelims{inner}{textcite}
+\RegisterCiteDelims{inner}{footcite}
+
 
 % smartcite is special
 % According to the docs it is like \parencite in a footnote and \footcite in
@@ -82,12 +101,90 @@
 % with \mkbibfootnote from the body), so we need to do it earlier.
 \newrobustcmd*{\mksmartcite}[1]{%
   \iffootnote
-    {\mkouterparencitedelim{%
+    {\mkouterparencitedelims{%
        \def\extblx@thisdelimcontext{parencite}%
        #1}}
     {\mkbibfootnote{%
        \def\extblx@thisdelimcontext{footcite}%
        #1}}}
+
+% Legacy names
+
+% compability for versions < 0.3
+\def\extblx@deprecate@delimcommand@robust#1{%
+  \protected\csedef{#1}{%
+    \noexpand\extblx@warning{%
+      \expandafter\string\csname#1\endcsname\space is deprecated.
+      \MessageBreak
+      Use \expandafter\string\csname#1s\endcsname\space (with s) instead.
+      \MessageBreak
+      Using \expandafter\string\csname#1s\endcsname\space}%
+  \expandonce{\csname#1s\endcsname}}}
+
+\extblx@deprecate@delimcommand@robust{DeclareOuterCiteDelim}
+\extblx@deprecate@delimcommand@robust{DeclareInnerCiteDelim}
+\extblx@deprecate@delimcommand@robust{UndeclareOuterCiteDelim}
+\extblx@deprecate@delimcommand@robust{UndeclareInnerCiteDelim}
+\extblx@deprecate@delimcommand@robust{DeclareOuterCiteDelimAlias}
+\extblx@deprecate@delimcommand@robust{DeclareInnerCiteDelimAlias}
+
+\newrobustcmd*{\extblx@create@mkcitedelim}{%
+  \extblx@warning{%
+    \string\extblx@create@mkcitedelim\space is deprecated.\MessageBreak
+    Use \string\RegisterCiteDelims\space instead.\MessageBreak
+    Using \string\RegisterCiteDelims\MessageBreak}
+  \RegisterCiteDelims}
+
+% Some very rudimentary backwards warning code for old names
+% this only warns, it can't salvage anything
+
+\AtEndDocument{%
+  \ifcsundef{abx@ffd@*@bbx:introcite}
+    {}
+    {\extblx@warning@noline{%
+       Field format 'bbx:introcite' defined.\MessageBreak
+       The format has been renamed to 'bbx@introcite'.\MessageBreak
+       This could mean that you are using the old name\MessageBreak
+       which does not work any more.\MessageBreak
+       Please use 'bbx@introcite' instead}}%
+  \ifcsundef{abx@ffd@*@bbx:introcitelabeldate}
+    {}
+    {\extblx@warning@noline{%
+       Field format 'bbx:introcitelabeldate'\MessageBreak
+       defined.\MessageBreak
+       The format has been renamed to\MessageBreak
+       'bbx@introcitelabeldate'.\MessageBreak
+       This could mean that you are using the old name\MessageBreak
+       which does not work any more.\MessageBreak
+       Please use\MessageBreak'bbx@introcitelabeldate'\MessageBreak instead}}%
+  \ifcsundef{blx@delimcontextalias@bbx:introcite}
+    {}
+    {\extblx@warning@noline{%
+       Delimiter context 'bbx:introcite' detected.\MessageBreak
+       The context has been renamed to 'bbx@introcite'.\MessageBreak
+       This could mean that you are using the old name\MessageBreak
+       which does not work any more.\MessageBreak
+       Please use 'bbx@introcite' instead}}%
+  \ifcsundef{extblx@citedelim@bbx:introcite@inner@open}
+    {}
+    {\extblx@warning@noline{%
+       Opening inner delimiter 'bbx:introcite' found.\MessageBreak
+       The delimiters have been renamed to\MessageBreak
+       'bbx@introcite'.\MessageBreak
+       This could mean that you are using the old name\MessageBreak
+       which does not work any more.\MessageBreak
+       Please use 'bbx@introcite' instead}}%
+  \ifcsundef{extblx@citedelim@bbx:introcite@inner@close}
+    {}
+    {\extblx@warning@noline{%
+       Closing inner delimiter 'bbx:introcite' found.\MessageBreak
+       The delimiters have been renamed to\MessageBreak
+       'bbx@introcite'.\MessageBreak
+       This could mean that you are using the old name\MessageBreak
+       which does not work any more.\MessageBreak
+       Please use 'bbx@introcite' instead}}%
+}
+
 
 \endinput
 %

--- a/ext-numeric-comp.cbx
+++ b/ext-numeric-comp.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{numeric-comp}
 
-\DeclareOuterCiteDelim{cite}{\bibopenbracket}{\bibclosebracket}
-\DeclareOuterCiteDelimAlias{parencite}{cite}
-\DeclareOuterCiteDelim{textcite}{}{}
+\DeclareOuterCiteDelims{cite}{\bibopenbracket}{\bibclosebracket}
+\DeclareOuterCiteDelimsAlias{parencite}{cite}
+\DeclareOuterCiteDelims{textcite}{}{}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenbracket}{\bibclosebracket}
+\DeclareInnerCiteDelims{textcite}{\bibopenbracket}{\bibclosebracket}
 
 \renewbibmacro*{textcite}{%
   \iffieldequals{namehash}{\cbx@lasthash}
@@ -36,7 +36,7 @@
      \stepcounter{textcitecount}%
      \savefield{namehash}{\cbx@lasthash}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -45,7 +45,7 @@
   {\usebibmacro{cite:dump}%
    \usebibmacro{postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{cite:init}%
    \usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
@@ -79,7 +79,7 @@
   {}
   {\usebibmacro{cite:dump}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{cite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
@@ -91,17 +91,17 @@
       \global\boolfalse{cbx:parens}}
      {}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
 
-\DeclareCiteCommand{\bbx@cite@inxref}[\mkouterbibinxrefcitedelim]
+\DeclareCiteCommand{\bbx@xrefcite}[\mkouterbbx@xrefcitedelims]
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \boolfalse{backtracker}%

--- a/ext-numeric-verb.cbx
+++ b/ext-numeric-verb.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{numeric-verb}
 
-\DeclareOuterCiteDelim{cite}{\bibopenbracket}{\bibclosebracket}
-\DeclareOuterCiteDelimAlias{parencite}{cite}
-\DeclareOuterCiteDelim{textcite}{}{}
+\DeclareOuterCiteDelims{cite}{\bibopenbracket}{\bibclosebracket}
+\DeclareOuterCiteDelimsAlias{parencite}{cite}
+\DeclareOuterCiteDelims{textcite}{}{}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenbracket}{\bibclosebracket}
+\DeclareInnerCiteDelims{textcite}{\bibopenbracket}{\bibclosebracket}
 
 \renewbibmacro*{textcite}{%
   \ifnameundef{labelname}
@@ -35,7 +35,7 @@
   {\usebibmacro{postnote}%
    \csuse{extblx@citedelim@cite@outer@close}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -51,7 +51,7 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\textcite}[\mkoutertextcitedelims]
   {}
   {\usebibmacro{citeindex}%
    \iffirstcitekey
@@ -63,11 +63,11 @@
   {\usebibmacro{postnote}%
    \csuse{extblx@citedelim@\blx@delimcontext @inner@close}}
 
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}
-\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelim]{\textcite}{}
+\DeclareMultiCiteCommand{\textcites}[\mkoutertextcitedelims]{\textcite}{}
 
 \endinput
 %

--- a/ext-numeric.cbx
+++ b/ext-numeric.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{numeric}
 
-\DeclareOuterCiteDelim{cite}{\bibopenbracket}{\bibclosebracket}
-\DeclareOuterCiteDelimAlias{parencite}{cite}
-\DeclareOuterCiteDelim{textcite}{}{}
+\DeclareOuterCiteDelims{cite}{\bibopenbracket}{\bibclosebracket}
+\DeclareOuterCiteDelimsAlias{parencite}{cite}
+\DeclareOuterCiteDelims{textcite}{}{}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenbracket}{\bibclosebracket}
+\DeclareInnerCiteDelims{textcite}{\bibopenbracket}{\bibclosebracket}
 
 \renewbibmacro*{textcite}{%
   \iffieldequals{namehash}{\cbx@lasthash}
@@ -49,14 +49,14 @@
          {}%
        \textcitedelim}}}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -72,19 +72,19 @@
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\usebibmacro{citeindex}%
    \usebibmacro{textcite}}
   {}
   {\usebibmacro{textcite:postnote}}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-standard.bbx
+++ b/ext-standard.bbx
@@ -11,15 +11,20 @@
 
 \providecommand*{\mkibid}[1]{#1}
 
-\newtoggle{bbx:citeinxref}
+\newtoggle{bbx:citexref}
 \newtoggle{bbx:innamebeforetitle}
 \newtoggle{bbx:innameidem}
 \newtoggle{bbx:articlein}
 \newtoggle{bbx:maintitleaftertitle}
 \newtoggle{bbx:introcite:plain:keeprelated}
 
+\DeclareBibliographyOption[boolean]{citexref}[true]{%
+  \settoggle{bbx:citexref}{#1}}
 \DeclareBibliographyOption[boolean]{citeinxref}[true]{%
-  \settoggle{bbx:citeinxref}{#1}}
+  \blx@warning{The option 'citeinxref' is deprecated.\MessageBreak
+    Use 'citexref' (without in) instead.\MessageBreak
+    Setting 'citexref' now}%
+  \settoggle{bbx:citexref}{#1}}
 \DeclareBibliographyOption[boolean]{innamebeforetitle}[true]{%
   \settoggle{bbx:innamebeforetitle}{#1}}
 \DeclareBibliographyOption[boolean]{innameidem}[true]{%
@@ -41,7 +46,7 @@
 \def\extblx@opt@introcite@plain{2}
 
 \ExecuteBibliographyOptions{%
-  citeinxref          = false,
+  citexref            = false,
   innamebeforetitle   = false,
   innameidem          = false,
   articlein           = true,
@@ -50,8 +55,13 @@
 % maxbibnames         = 999,
 }
 
+\DeclareTypeOption[boolean]{citexref}[true]{%
+  \settoggle{bbx:citexref}{#1}}
 \DeclareTypeOption[boolean]{citeinxref}[true]{%
-  \settoggle{bbx:citeinxref}{#1}}
+  \blx@warning{The option 'citeinxref' is deprecated.\MessageBreak
+    Use 'citexref' (without in) instead.\MessageBreak
+    Setting 'citexref' now}%
+  \settoggle{bbx:citexref}{#1}}
 \DeclareTypeOption[boolean]{innamebeforetitle}[true]{%
   \settoggle{bbx:innamebeforetitle}{#1}}
 \DeclareTypeOption[boolean]{innameidem}[true]{%
@@ -61,8 +71,13 @@
 \DeclareTypeOption[boolean]{maintitleaftertitle}[true]{%
   \settoggle{bbx:maintitleaftertitle}{#1}}
 
+\DeclareEntryOption[boolean]{citexref}[true]{%
+  \settoggle{bbx:citexref}{#1}}
 \DeclareEntryOption[boolean]{citeinxref}[true]{%
-  \settoggle{bbx:citeinxref}{#1}}
+  \blx@warning{The option 'citeinxref' is deprecated.\MessageBreak
+    Use 'citexref' (without in) instead.\MessageBreak
+    Setting 'citexref' now}%
+  \settoggle{bbx:citexref}{#1}}
 \DeclareEntryOption[boolean]{innamebeforetitle}[true]{%
   \settoggle{bbx:innamebeforetitle}{#1}}
 \DeclareEntryOption[boolean]{innameidem}[true]{%
@@ -75,9 +90,9 @@
 
 \newbibmacro*{bbx:introcite}{\usebibmacro{cite}}
 
-\extblx@create@mkcitedelim{inner}{bbx:introcite}
-\DeclareInnerCiteDelimAlias{bbx:introcite}{cite}
-\DeclareFieldFormat{bbx:introcite}{#1}
+\RegisterCiteDelims{inner}{bbx@introcite}
+\DeclareInnerCiteDelimsAlias{bbx@introcite}{cite}
+\DeclareFieldFormat{bbx@introcite}{#1}
 \newcommand*{\introcitepunct}{\addcolon\space}
 \newcommand*{\introcitebreak}{\leavevmode\newline}
 
@@ -93,7 +108,7 @@
       {}
       {\togglefalse{blx@bibliography}%
        \toggletrue{blx@citation}}%
-    \delimcontext{bbx:introcite}%
+    \delimcontext{bbx@introcite}%
     \csuse{blx@hook@cite}%
     \csuse{blx@hook@citekey}%
     \DeclareFieldFormat{bibhyperref}{##1}%
@@ -101,7 +116,7 @@
     \undef\cbx@lastyear
     \citetrackerfalse\pagetrackerfalse\backtrackerfalse
     \defcounter{maxnames}{\blx@maxcitenames}%
-    \printtext[bbx:introcite]{\usebibmacro{bbx:introcite}}%
+    \printtext[bbx@introcite]{\usebibmacro{bbx:introcite}}%
   \endgroup
 }
 
@@ -119,27 +134,30 @@
     {}}
 
 
-\newbibmacro*{bbx:cite:inxref}{\usebibmacro{cite}}
+\newbibmacro*{bbx:inxrefcite}{\usebibmacro{cite}}
 
-\DeclareCiteCommand{\bbx@cite@inxref}[\mkouterbibinxrefcitedelim]
+\DeclareCiteCommand{\bbx@xrefcite}[\mkouterbbx@xrefcitedelims]
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \boolfalse{backtracker}}
-  {\usebibmacro{bbx:cite:inxref}}
+  {\usebibmacro{bbx:inxrefcite}}
   {}
   {}
 
-\DeclareDelimcontextAlias{bbx@cite@inxref}{cite}
-\DeclareOuterCiteDelimAlias{bibinxrefcite}{cite}
+\RegisterCiteDelims{outer}{bbx@xrefcite}
+\DeclareOuterCiteDelimsAlias{bbx@xrefcite}{cite}
+\RegisterCiteDelims{inner}{bbx@xrefcite}
+\DeclareInnerCiteDelimsAlias{bbx@xrefcite}{cite}
+\DeclareDelimcontextAlias{bbx@xrefcite}{cite}
 
 
 \newbibmacro*{crosscite}[1]{%
-  \iftoggle{bbx:citeinxref}
+  \iftoggle{bbx:citexref}
     {\iffieldundef{crossref}
        {\iffieldundef{xref}
           {\usebibmacro{#1}}
-          {\printtext{\bbx@cite@inxref{\thefield{xref}}}}}
-       {\printtext{\bbx@cite@inxref{\thefield{crossref}}}}}
+          {\printtext{\bbx@xrefcite{\thefield{xref}}}}}
+       {\printtext{\bbx@xrefcite{\thefield{crossref}}}}}
     {\usebibmacro{#1}}}
 
 \DeclareDelimAlias{innametitledelim}{nametitledelim}

--- a/ext-verbose-ibid.cbx
+++ b/ext-verbose-ibid.cbx
@@ -5,18 +5,18 @@
 
 \RequireCitationStyle{verbose-ibid}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -32,7 +32,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -45,12 +45,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-verbose-inote.cbx
+++ b/ext-verbose-inote.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{verbose-inote}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \iffootnote
@@ -18,7 +18,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \iffootnote
@@ -38,7 +38,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -51,12 +51,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-verbose-note.cbx
+++ b/ext-verbose-note.cbx
@@ -5,11 +5,11 @@
 
 \RequireCitationStyle{verbose-note}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \iffootnote
@@ -18,7 +18,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \iffootnote
@@ -38,7 +38,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -51,12 +51,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-verbose-trad1.cbx
+++ b/ext-verbose-trad1.cbx
@@ -5,18 +5,18 @@
 
 \RequireCitationStyle{verbose-trad1}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -32,7 +32,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -45,12 +45,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-verbose-trad2.cbx
+++ b/ext-verbose-trad2.cbx
@@ -5,18 +5,18 @@
 
 \RequireCitationStyle{verbose-trad2}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -32,7 +32,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -45,12 +45,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-verbose-trad3.cbx
+++ b/ext-verbose-trad3.cbx
@@ -5,18 +5,18 @@
 
 \RequireCitationStyle{verbose-trad3}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -32,7 +32,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -45,12 +45,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}

--- a/ext-verbose.cbx
+++ b/ext-verbose.cbx
@@ -5,18 +5,18 @@
 
 \RequireCitationStyle{verbose}
 
-\DeclareOuterCiteDelim{parencite}{\bibopenparen}{\bibcloseparen}
+\DeclareOuterCiteDelims{parencite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareInnerCiteDelim{textcite}{\bibopenparen}{\bibcloseparen}
+\DeclareInnerCiteDelims{textcite}{\bibopenparen}{\bibcloseparen}
 
-\DeclareCiteCommand{\cite}[\mkoutercitedelim]
+\DeclareCiteCommand{\cite}[\mkoutercitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\parencite}[\mkouterparencitedelim]
+\DeclareCiteCommand{\parencite}[\mkouterparencitedelims]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
    \usebibmacro{cite}}
@@ -32,7 +32,7 @@
   {\multicitedelim}
   {\usebibmacro{cite:postnote}}
 
-\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelim]
+\DeclareCiteCommand{\cbx@textcite}[\mkoutertextcitedelims]
   {\usebibmacro{textcite:init}}
   {\iffieldequals{namehash}{\cbx@lasthash}
      {}
@@ -45,12 +45,12 @@
   {}
   {}
 
-\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelim]
+\DeclareMultiCiteCommand{\cbx@textcites}[\mkoutertextcitedelims]
   {\cbx@textcite}{}
 
-\DeclareMultiCiteCommand{\cites}[\mkoutercitedelim]
+\DeclareMultiCiteCommand{\cites}[\mkoutercitedelims]
   {\cite}{\multicitedelim}
-\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelim]
+\DeclareMultiCiteCommand{\parencites}[\mkouterparencitedelims]
   {\parencite}{\multicitedelim}
 \DeclareMultiCiteCommand{\smartcites}[\mksmartcite]
   {\smartcite}{\multicitedelim}


### PR DESCRIPTION
   - Add an "`s`" to make most `Declare...CiteDelim` macros read "`Delims`" instead
      of "`Delim`" (they are about opening *and* closing delimiters after all).
      - There is full backwards compatibility for this change. Of course the new
        names are encouraged, the old names throw a warning.
    - The `citeinxref` option is now `citexref` only.
      - The old name throws a warning and sets `citexref`.
    - Rename `\bbx@cite@inxref` to `\bbx@xrefcite`.
      - There is no backwards compatibility code for that change.
        The macros are largely used internally and are not explained in the manual,
        so hopefully that is OK.
    - Rename the virtual `\bbx:introcite` to `\bbx@introcite`.
      - Full backwards compatibility was not really feasible here, so `biblatex-ext`
        only checks if something which looks like the old name was used and throws
        a warning with suggestions for the new names. This can't catch everything,
        but should definitely be enough for the examples in the manual.
- Fix an consistency in `\textcite`'s inner delimiters.