### PR TITLE
Fix labelprefix not working properly with latest changes in biblatex

### DIFF
--- a/biblatex-ext-tabular.sty
+++ b/biblatex-ext-tabular.sty
@@ -87,7 +87,7 @@
          \blx@xml@dlist@refcontext
            {\blx@refcontext@sortingtemplatename}
            {\blx@refcontext@sortingnamekeytemplatename}
-           {\blx@refcontext@labelprefix}
+           {\ifdef{\blx@refcontext@labelprefix@real}{\blx@refcontext@labelprefix@real}{\blx@refcontext@labelprefix}}
            {\blx@refcontext@uniquenametemplatename}
            {\blx@refcontext@labelalphanametemplatename}}{}}}%
   \ifdefvoid\blx@tempa


### PR DESCRIPTION
This fixes a regression caused by https://github.com/plk/biblatex/commit/6338b39d3a2bea5cfc1047dcaecc3dec1e5bccfa and https://github.com/plk/biblatex/commit/1f4803806162bc87f10690269e9bbb1554b9061d in the biblatex package, which since Oct 2018 uses MD5 hashes to encode label prefixes.

Before this change, any bib entries included in a bibtabular would show up as [EA57D51A5...1],
since the reference context created does not use the `\blx@refcontext@labelprefix@real` command
that returns the regular, unhashed labelprefix.

MWE:
```latex
\documentclass{article}

\usepackage[style=numeric,defernumbers=true]{biblatex}
\usepackage{biblatex-ext-tabular}

\addbibresource{test.bib}

% Quickly define a tabular style
\defbibtabular{bibtabular}{
	\begin{tabular}
		{|l|p{8cm}|}
		\hline 
		Author & Reference \\
		\hline
	}
	{\end{tabular}}
{\anchorlang{\usebibmacro{tabular:sortname}} &\driver{\usebibmacro{tabular:omitsortname}} \\ \hline}

\begin{document}

 % Start a reference context where every citation has to be prefixed by 'A'
\begin{refcontext}[labelprefix=A]
	\cite{Knuth1984} % should show [A1]
	\printbibtabular
\end{refcontext}

\end{document}
```

![Actual result](https://user-images.githubusercontent.com/720678/80979081-91444900-8e2f-11ea-97a0-eacb03c6ca47.png)

![Expected result](https://user-images.githubusercontent.com/720678/80979603-3e1ec600-8e30-11ea-9d3a-020f18782278.png)


And a proposed workaround using `\patchcmd` to perform the change without editing the source file of the library:
```latex
\makeatletter
\patchcmd%
	\extblxtab@printbibtabular% % Patch the internal \printbibtabular command
	{{\blx@refcontext@labelprefix}}% % Find the label prefix in the \blx@xml@dlist@refcontext call
	{{\ifdef{\blx@refcontext@labelprefix@real}{\blx@refcontext@labelprefix@real}{\blx@refcontext@labelprefix}}}% % Replace it with the actual, non-MD5 label prefix (if this functionality has been implemented)
	{}{}
\makeatother
```